### PR TITLE
Rework the solution for generating integers correctly in JSON data

### DIFF
--- a/lib/WWW/Cachet/Component.pm
+++ b/lib/WWW/Cachet/Component.pm
@@ -9,10 +9,10 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
@@ -27,9 +27,9 @@ has description => (
 
 has status => (
   is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "Invalid component status" unless ($_[0] =~ /^[1-4]$/); 
-    $_[0] += 0;
+    confess "Invalid component status" unless ((my $var = $_[0]) =~ /^[1-4]$/);
   },
   required => TRUE
 );
@@ -39,13 +39,13 @@ has status_name => (
 );
 
 has tags => (
-  is => 'rw',
-  isa => sub {
+  is       => 'rw',
+  isa      => sub {
     if ($_) {
       confess "Expected 'tags' to be a hash" unless (ref $_[0] eq "HASH");
     }
   },
-  default => sub { undef }
+  default  => sub { undef }
 );
 
 has link => (
@@ -58,9 +58,9 @@ has order => (
 
 has group_id => (
   is       => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 

--- a/lib/WWW/Cachet/ComponentGroup.pm
+++ b/lib/WWW/Cachet/ComponentGroup.pm
@@ -8,10 +8,10 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
@@ -21,19 +21,19 @@ has name => (
 );
 
 
-has order  => (
-  is  =>'rw', 
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+has order => (
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
 has collapsed => (
   is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "'collapsed' should be 0, 1 or 2" unless ($_[0] =~ /^[012]$/);
-    $_[0] += 0;
+    confess "'collapsed' should be 0, 1 or 2" unless ((my $var = $_[0]) =~ /^[012]$/);
   },
   default  => sub { 0 }
 );

--- a/lib/WWW/Cachet/Incident.pm
+++ b/lib/WWW/Cachet/Incident.pm
@@ -9,10 +9,10 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
@@ -28,36 +28,36 @@ has message => (
 
 has status => (
   is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "Invalid incident status" unless ($_[0] =~ /^[0-4]$/); 
-    $_[0] += 0;
+    confess "Invalid incident status" unless ((my $var = $_[0]) =~ /^[0-4]$/);
   },
   required => TRUE
 );
 
 has visible => (
   is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "'visible' should be 1 or 0" unless ($_[0] =~ /^[01]$/);
-    $_[0] += 0;
+    confess "'visible' should be 1 or 0" unless ((my $var = $_[0]) =~ /^[01]$/);
   },
   required => TRUE
 );
 
 has component_id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
 has component_status => (
   is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "Invalid incident component status" unless ($_[0] =~ /^[1-4]$/);
-    $_[0] += 0;
-  },
+    confess "Invalid incident component status" unless ((my $var = $_[0]) =~ /^[1-4]$/);
+  }
 );
 
 has notify => (

--- a/lib/WWW/Cachet/Metric.pm
+++ b/lib/WWW/Cachet/Metric.pm
@@ -9,10 +9,10 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
@@ -32,19 +32,19 @@ has description => (
 );
 
 has default_value => (
-  is  =>'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   },
   required => TRUE
 );
 
 has calc_type => (
-  is => 'rw',
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
   isa      => sub {
-    confess "'calc_type' should be CALC_TYPE_AVERAGE (1) or or CALC_TYPE_SUM (0)" unless ($_[0] =~ /^[01]$/);
-    $_[0] += 0;
+    confess "'calc_type' should be CALC_TYPE_AVERAGE (1) or or CALC_TYPE_SUM (0)" unless ((my $var = $_[0]) =~ /^[01]$/);
   },
 );
 

--- a/lib/WWW/Cachet/MetricPoint.pm
+++ b/lib/WWW/Cachet/MetricPoint.pm
@@ -8,18 +8,18 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
 has metric_id  => (
-  is  =>'rw', 
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
@@ -30,9 +30,9 @@ has value => (
 
 has timestamp  => (
   is       => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 

--- a/lib/WWW/Cachet/Subscriber.pm
+++ b/lib/WWW/Cachet/Subscriber.pm
@@ -9,21 +9,21 @@ extends 'WWW::Cachet::Object';
 use Carp qw/ confess /;
 
 has id => (
-  is  => 'rw',
-  isa => sub {
-    confess "'$_[0]' is not an integer!" if $_[0] !~ /^\d+$/;
-    $_[0] += 0;
+  is       => 'rw',
+  coerce   => sub { $_[0] + 0 },
+  isa      => sub {
+    confess "'$_[0]' is not an integer!" if ((my $var = $_[0]) !~ /^\d+$/);
   }
 );
 
 has email => (
-  is       =>'rw', 
+  is       => 'rw',
   required => TRUE
 );
 
 has verify => (
-  is => 'rw',
-  coerce => sub {
+  is       => 'rw',
+  coerce   => sub {
     return (!$_[0] || $_[0] eq 'false' ? JSON::false : JSON::true);
   },
 );
@@ -33,18 +33,18 @@ has components => (
 );
 
 has global => (
-  is => 'rw',
-  coerce => sub {
+  is       => 'rw',
+  coerce   => sub {
     return (!$_[0] || $_[0] eq 'false' ? JSON::false : JSON::true);
   },
 );
 
 has verify_code => (
-  is  =>'rw', 
+  is  => 'rw',
 );
 
 has verified_at => (
-  is  =>'rw', 
+  is  => 'rw',
 );
 
 has created_at => (
@@ -56,13 +56,13 @@ has updated_at => (
 );
 
 has subscriptions => (
-  is => 'rw',
-  isa => sub {
+  is       => 'rw',
+  isa      => sub {
     if ($_) {
       confess "Expected 'subscriptions' to be an array" unless (ref $_[0] eq "ARRAY");
     }
   },
-  default => sub { undef }
+  default  => sub { undef }
 );
 
 1;


### PR DESCRIPTION
The previous solution worked fine with Perl 5.14, but caused errors
like the following with Perl 5.18:

  isa check for "status" failed: Modification of a read-only value attempted

Change-Id: I56770e3584a93621df47a9fc149597261c3b6c95